### PR TITLE
upgrade for springboot 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>hipaa-audit</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1</version>
     <packaging>jar</packaging>
 
     <name>wily-hipaa-audit</name>
@@ -33,13 +33,13 @@
     </scm>
 
     <properties>
-        <wily-security.version>2.7.0</wily-security.version>
+        <wily-security.version>2.7.1</wily-security.version>
     </properties>
 
     <parent>
         <groupId>io.csra.wily</groupId>
         <artifactId>dependencies</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.1</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Update wily-hippa-audit version to 2.7.1
wily-security must be deployed first